### PR TITLE
Fix `link.sh` and `clean.sh` verbose flag

### DIFF
--- a/lib/clean.sh
+++ b/lib/clean.sh
@@ -43,7 +43,9 @@ function dotfiles_clean {
       if [[ -L "$dest_path" ]] ; then
         # delete the symlink
         rm -f "$dest_path"
-        [[ $verbose == true ]] && echo "rm    ${dest_path}"
+        if [[ $verbose == true ]] ; then
+          echo "rm    ${dest_path}"
+        fi
       fi
 
       # check if the file is a backup
@@ -51,7 +53,9 @@ function dotfiles_clean {
       if [[ -e "$bak_file" ]] ; then
         # restore the backup
         mv "$bak_file" "$dest_path"
-        [[ $verbose == true ]] && echo "mv    ${bak_file} ${dest_path}"
+        if [[ $verbose == true ]] ; then
+          echo "mv    ${bak_file} ${dest_path}"
+        fi
       fi
 
       # check if the directory is empty
@@ -59,7 +63,9 @@ function dotfiles_clean {
         if [[ -z "$(ls -A "$dest_dir")" ]] ; then
           # delete the directory
           rm -rf "$dest_dir"
-          [[ $verbose == true ]] && echo "rm -r ${dest_dir}"
+          if [[ $verbose == true ]] ; then
+            echo "rm -r ${dest_dir}"
+          fi
         fi
       fi
     done

--- a/lib/link.sh
+++ b/lib/link.sh
@@ -48,16 +48,22 @@ function dotfiles_link {
       if [[ -e "$dest_path" && ! -L "$dest_path" ]] ; then
         # backup the existing file
         mv "$dest_path" "${dest_path}.bak"
-        [[ $verbose == true ]] && echo "mv       ${dest_path} ${dest_path}.bak"
+        if [[ $verbose == true ]] ; then
+          echo "mv       ${dest_path} ${dest_path}.bak"
+        fi
       fi
 
       # create the target directory
       mkdir -p "$dest_dir"
-      [[ $verbose == true ]] && echo "mkdir -p ${dest_dir}"
+      if [[ $verbose == true ]] ; then
+        echo "mkdir -p ${dest_dir}"
+      fi
 
       # create the symlink
       ln -sf "$file_path" "$dest_path"
-      [[ $verbose == true ]] && echo "ln -s    ${file_path} ${dest_path}"
+      if [[ $verbose == true ]] ; then
+        echo "ln -s    ${file_path} ${dest_path}"
+      fi
     done
   done
 }


### PR DESCRIPTION
Don't do this:

```sh
[[ $var == 'val' ]] && echo 'something'
```

Because it won't exit with a 0 if `$var` is not set. Do this:

```sh
if [[ $var == 'val' ]] ; then
  echo 'something'
fi
```
